### PR TITLE
feat: added logout session handling

### DIFF
--- a/src/main/java/dpapps/controller/UserController.java
+++ b/src/main/java/dpapps/controller/UserController.java
@@ -66,7 +66,6 @@ public class UserController {
 
     @PostMapping("/updateProfile")
     public String updateProfile(@ModelAttribute User updatedUser) {
-        System.out.println(updatedUser.getId());
         return this.controllerService.updateProfile(updatedUser);
     }
 

--- a/src/main/java/dpapps/security/SpringSecurity.java
+++ b/src/main/java/dpapps/security/SpringSecurity.java
@@ -61,7 +61,9 @@ public class SpringSecurity {
                         .permitAll()
                 )
                 .logout(logout -> logout
-                        .logoutRequestMatcher(new AntPathRequestMatcher("/logout")).permitAll())
+                        .logoutRequestMatcher(new AntPathRequestMatcher("/logout")).permitAll()
+                        .logoutSuccessUrl("/login?logout")
+                )
                 .sessionManagement((sessionManagement) ->
                         sessionManagement
                                 .sessionConcurrency((sessionConcurrency) ->

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -37,11 +37,47 @@
 
             <li><a class="nav-link" sec:authorize="isAuthenticated()" th:href="@{/profile}">Profile</a></li>
 
-            <li><a class="nav-link" sec:authorize="isAuthenticated()" th:href="@{/logout}">Logout</a></li>
-
+            <li><a class="nav-link" id="logoutLink" sec:authorize="isAuthenticated()" th:href="@{#}">Logout</a></li>
 
         </ul>
+
+
     </div>
+    <div class="modal" tabindex="-1" role="dialog" id="logoutModal">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Logout Confirmation</h5>
+                </div>
+                <div class="modal-body">
+                    <p>Are you sure you want to logout?</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal" id="buttonCancel">Cancel
+                    </button>
+                    <a class="btn btn-primary" th:href="@{/logout}">Logout</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+
+        var btnLogout = document.getElementById("logoutLink");
+
+        var btnCancel = document.getElementById("buttonCancel")
+
+        var modal = document.getElementById("logoutModal");
+
+
+        btnLogout.onclick = function () {
+            modal.style.display = "block";
+        }
+
+        btnCancel.onclick = function () {
+            modal.style.display = "none";
+        }
+    </script>
 </nav>
 </body>
 </html>


### PR DESCRIPTION
feat: clearing user session upon logout
This funcionality was avaibable when Spring Security was added (PR #14 ). 
By default when using Spring Security and accessing /logout endpoint will log user out by:
- Invalidating the HTTP Session
- Cleaning up any RememberMe authentication that was configured
- Clearing the SecurityContextHolder
- Clearing the SecurityContextRepository
- Redirect to /login?logout

feat: prevent back button to re-enter the app without login.
This funcionality was avaibable when Spring Security was added (PR #14 ). 
According to these information its impossible to click back button and access authenticated user enpoints.
Spring Security checks if user is authenticated and has required role while accessing an endpoint, if not user is redirected to /login screen

feat: Display a confirmation before logout.
Added JavaScript code which displays a popup window when User tries to logout

feat: Display successful logout message.
This funcionality was added in (PR #16 )

feat: Redirect to the login page.
This funcionality was added in (PR #16 )
According to the Spring Security documentation /login?logout is called by default by logging out, but I added Spring Security configuration entry which acheives that.